### PR TITLE
Closes #7: Update info methods in Registration_Example

### DIFF
--- a/Registration_Example.ipynb
+++ b/Registration_Example.ipynb
@@ -8,8 +8,9 @@
     "In this example we will:\n",
     "- Create random pdarrays and Strings\n",
     "- Register these objects\n",
-    "- Verify their registration status using `ak.list_registry`, `is_registered`, and `ak.info`\n",
-    "- Remove all non-register objects from the symbol table using `ak.clear`\n",
+    "- Verify their registration status using `ak.list_registry`, `.is_registered`, and `.info`\n",
+    "- Convert `ak.information`'s JSON return string into a python object \n",
+    "- Remove all non-registered objects from the symbol table using `ak.clear`\n",
     "- Disconnect from the arkouda server\n",
     "- Reconnect to the arkouda server\n",
     "- Attach to all registered objects\n",
@@ -25,7 +26,10 @@
     "- `ak.list_registry`\n",
     "- `ak.pdarray.is_registered`\n",
     "- `ak.Strings.is_registered`\n",
-    "- `ak.info`\n",
+    "- `ak.Strings.info`\n",
+    "- `ak.Strings.pretty_print_info`\n",
+    "- `ak.infomation`\n",
+    "- `ak.pretty_print_information`\n",
     "- `ak.clear`\n",
     "- `ak.disconnect`\n",
     "- `ak.pdarray.attach`\n",
@@ -74,7 +78,7 @@
    "metadata": {},
    "source": [
     "#### Intializing and Registering Variables\n",
-    "We create random `pdarray` and `Strings` objects and register them using in place `register` functions"
+    "We create random `pdarray` and `Strings` objects and register them using in place `.register` functions"
    ]
   },
   {
@@ -103,8 +107,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Verifying Registration\n",
-    "We have just registered `pdarray pda1` and `String str1`. Note that `pdarray pda2` and `String str2` have not been registered. We can verify this using `ak.list_registry`, `is_registered`, or `ak.info`"
+    "#### Verifying Registration and Using Information Methods\n",
+    "We have just registered `pdarray pda1` and `String str1`. Note that `pdarray pda2` and `String str2` have not been registered. We can verify this using `ak.list_registry`, `.is_registered`, or `.info`"
    ]
   },
   {
@@ -123,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Object.is_registered() returns a boolean indicating the objects registration status\n",
+    "# Class level .is_registered() returns a boolean indicating the object's registration status\n",
     "print(f'pda1 is registered: {pda1.is_registered()}')\n",
     "print(f'pda2 is registered: {pda2.is_registered()}')\n",
     "print(f'str1 is registered: {str1.is_registered()}')\n",
@@ -136,31 +140,100 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ak.info returns all attributes of an object\n",
-    "# ak.info can be called with a single object, all registered objects, or all objects\n",
+    "# Class level .info returns all attributes of an object in a JSON formatted string\n",
     "\n",
-    "print(\"ak.info('registered_object_name'):\")\n",
-    "print(ak.info('pda1'))\n",
+    "print(\"str1.info():\")\n",
+    "print(str1.info())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Class level .pretty_print_info returns all the attributes from .info in human readable form\n",
     "\n",
-    "print('ak.info(ak.RegisteredSymbols):')\n",
-    "print(ak.info(ak.RegisteredSymbols))\n",
-    "\n",
-    "print('ak.info(ak.AllSymbols):')\n",
-    "print(ak.info(ak.AllSymbols))"
+    "print(\"str1.pretty_print_info():\")\n",
+    "str1.pretty_print_info()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see `ak.info(ak.RegisteredSymbols)` only contains references to objects related to `pda1` and `str1`"
+    "Using `ak.information` and `ak.pretty_print_information` it's easy to get attributes of all objects in the registry/symbol table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ak.information returns all attributes of an object in a JSON formatted string\n",
+    "# ak.information can be called with a single object, all registered objects, or all objects\n",
+    "\n",
+    "print(\"ak.information('registered_object_name'):\")\n",
+    "print(ak.information('pda1'))\n",
+    "\n",
+    "print('\\nak.information(ak.RegisteredSymbols):')\n",
+    "print(ak.information(ak.RegisteredSymbols))\n",
+    "\n",
+    "print('\\nak.information(ak.AllSymbols):')\n",
+    "print(ak.information(ak.AllSymbols))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# all the same arguments can be passed into ak.pretty_print_information for human readable output\n",
+    "print(\"ak.pretty_print_information('registered_object_name'):\")\n",
+    "ak.pretty_print_information('pda1')\n",
+    "\n",
+    "print('\\nak.pretty_print_information(ak.RegisteredSymbols):')\n",
+    "ak.pretty_print_information(ak.RegisteredSymbols)\n",
+    "\n",
+    "print('\\nak.pretty_print_information(ak.AllSymbols):')\n",
+    "ak.pretty_print_information(ak.AllSymbols)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ak.clear()` removes all non-registered objects from the symbol table, so `ak.info(ak.AllSymbols)` is different after a clear"
+    "We can see `ak.pretty_print_information(ak.RegisteredSymbols)` only contains references to objects related to `pda1` and `str1`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The JSON formmated string that's returned by `ak.information` and class level `.info` functions can be turned into a list of dictionaries in python using `json.loads` from the `json` library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The JSON output of ak.information and .info can be parsed into python using the JSON library\n",
+    "import json\n",
+    "\n",
+    "uint8_list = [symbol for symbol in json.loads(ak.information(ak.AllSymbols)) if symbol['dtype'] == 'uint8']\n",
+    "for sym in uint8_list:\n",
+    "    print(sym)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`ak.clear()` removes all non-registered objects from the symbol table, so `ak.pretty_print_information(ak.AllSymbols)` is different after a clear"
    ]
   },
   {
@@ -170,10 +243,12 @@
    "outputs": [],
    "source": [
     "print('Before clear:')\n",
-    "print(ak.info(ak.AllSymbols))\n",
+    "ak.pretty_print_information(ak.AllSymbols)\n",
+    "\n",
     "ak.clear()\n",
-    "print('After clear:')\n",
-    "print(ak.info(ak.AllSymbols))\n"
+    "\n",
+    "print('\\nAfter clear:')\n",
+    "ak.pretty_print_information(ak.AllSymbols)"
    ]
   },
   {
@@ -224,7 +299,7 @@
    "outputs": [],
    "source": [
     "# connect to the arkouda server using the connect_url which the server prints out\n",
-    "ak.connect(connect_url=\"tcp://localhost:5555\")"
+    "ak.connect(\"localhost\")"
    ]
   },
   {
@@ -251,7 +326,8 @@
    "outputs": [],
    "source": [
     "print('After reconnect to server:')\n",
-    "print(ak.info(ak.AllSymbols))"
+    "# ak.pretty_print_information and ak.information without arguments defaults to ak.RegisteredSymbols\n",
+    "ak.pretty_print_information()"
    ]
   },
   {
@@ -305,7 +381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(ak.info(ak.AllSymbols))"
+    "print(ak.information(ak.AllSymbols))"
    ]
   },
   {


### PR DESCRIPTION
This PR (Issue #7):
- Updates `Registration_Example.ipynb` to use `ak.information` and `ak.pretty_print_information`
- Adds `.info` and `.pretty_print_info` for `pdarray` and `Strings`
- Adds an example of how to convert JSON return string of `ak.information` into a Python object

The notebook can easily be viewed [here](https://nbviewer.jupyter.org/github/pierce314159/ArkoudaNotebooks/blob/7_info_registration_example/Registration_Example.ipynb) until this PR is merged