### PR TITLE
Closes #9: Update ak.info calls in notebooks to new interface

### DIFF
--- a/NYCTaxi.ipynb
+++ b/NYCTaxi.ipynb
@@ -293,7 +293,7 @@
    "outputs": [],
    "source": [
     "# print out the arkouda server symbol table\n",
-    "print(ak.info(ak.AllSymbols))"
+    "ak.pretty_print_information(ak.AllSymbols)"
    ]
   },
   {


### PR DESCRIPTION
Closes #9 Update ak.info calls in notebooks to new interface:
- Updates `NYCTaxi.ipynb` to use `ak.pretty_print_information(ak.AllSymbols)` in place of `print(ak.info(ak.AllSymbols))`