### PR TITLE
Closes #20: Updating Registration Example Notebook for Gen Attach and register GroupBy

### DIFF
--- a/Registration_Example.ipynb
+++ b/Registration_Example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Arkouda Registration Example\n",
     "In this example we will:\n",
-    "- Create random pdarrays and Strings\n",
+    "- Create random pdarrays, Strings, Categoricals, SegArrays, and GroupBys\n",
     "- Register these objects\n",
     "- Verify their registration status using `ak.list_registry`, `.is_registered`, and `.info`\n",
     "- Convert `ak.information`'s JSON return string into a python object \n",
@@ -23,19 +23,28 @@
     "- `ak.random_strings_uniform`\n",
     "- `ak.pdarray.register`\n",
     "- `ak.Strings.register`\n",
+    "- `ak.Categorical.register`\n",
+    "- `ak.SegArray.register`\n",
+    "- `ak.GroupBy.register`\n",
     "- `ak.list_registry`\n",
     "- `ak.pdarray.is_registered`\n",
     "- `ak.Strings.is_registered`\n",
+    "- `ak.Categorical.is_registered`\n",
+    "- `ak.SegArray.is_registered`\n",
+    "- `ak.GroupBy.is_registered`\n",
     "- `ak.Strings.info`\n",
     "- `ak.Strings.pretty_print_info`\n",
     "- `ak.infomation`\n",
     "- `ak.pretty_print_information`\n",
     "- `ak.clear`\n",
     "- `ak.disconnect`\n",
-    "- `ak.pdarray.attach`\n",
-    "- `ak.Strings.attach`\n",
+    "- `ak.attach`\n",
+    "- `ak.GroupBy.attach`\n",
     "- `ak.pdarray.unregister`\n",
     "- `ak.Strings.unregister`\n",
+    "- `ak.Categorical.unregister`\n",
+    "- `ak.SegArray.unregister`\n",
+    "- `ak.GroupBy.unregister`\n",
     "- `ak.shutdown`\n"
    ]
   },
@@ -49,9 +58,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    _         _                   _       \n",
+      "   / \\   _ __| | _____  _   _  __| | __ _ \n",
+      "  / _ \\ | '__| |/ / _ \\| | | |/ _` |/ _` |\n",
+      " / ___ \\| |  |   < (_) | |_| | (_| | (_| |\n",
+      "/_/   \\_\\_|  |_|\\_\\___/ \\__,_|\\__,_|\\__,_|\n",
+      "                                          \n",
+      "\n",
+      "Client Version: v2022.05.09+19.g81249870\n"
+     ]
+    }
+   ],
    "source": [
     "import arkouda as ak"
    ]
@@ -65,9 +89,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/josh/git/arkouda/arkouda/client.py:147: RuntimeWarning: Version mismatch between client (v2022.05.09+19.g81249870) and server (v2022.05.09+15.g8ea55dba.dirty); this may cause some commands to fail or behave incorrectly! Updating arkouda is strongly recommended.\n",
+      "  warnings.warn(('Version mismatch between client ({}) and server ({}); ' +\n",
+      "connected to arkouda server tcp://*:5555\n"
+     ]
+    }
+   ],
    "source": [
     "# connect to the arkouda server using the connect_url which the server prints out\n",
     "ak.connect(connect_url=\"tcp://localhost:5555\")"
@@ -78,29 +112,108 @@
    "metadata": {},
    "source": [
     "#### Intializing and Registering Variables\n",
-    "We create random `pdarray` and `Strings` objects and register them using in place `.register` functions"
+    "We create random `pdarray`, `Strings`, `Categorical`, `SegArray`, and `GroupBy` objects and register them using in place `.register` functions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "pda1 = ak.randint(0,10,100)\n",
     "pda2 = ak.randint(0,10,100)\n",
     "str1 = ak.random_strings_uniform(2, 5, 100)\n",
-    "str2 = ak.random_strings_uniform(2, 5, 100)"
+    "str2 = ak.random_strings_uniform(2, 5, 100)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Categorical` is built from `Strings` objects, so here we're using our `Strings` objects to create our `Categorical` objects"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
+    "cat1 = ak.Categorical(str1)\n",
+    "cat2 = ak.Categorical(str2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SegArray` is a segmented array built from multiple `pdarray`s of varying length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, we generate three lists that are then flattened into a single list\n",
+    "a = [10, 11, 12, 13, 14, 15]\n",
+    "b = [20, 21]\n",
+    "c = [30, 31, 32, 33]\n",
+    "flat = a + b + c\n",
+    "\n",
+    "# Then, we turn this flattened list into a pdarray\n",
+    "akflat = ak.array(flat)\n",
+    "\n",
+    "# Next, we create a pdarray for the segments, which can be thought of as the starting index in the flattened array for each of the three intial lists\n",
+    "# In this case, 0 is the start of the first segment, list a; the length of list a, 6, is the start of the second segment, list b; and the combined length\n",
+    "# of lists a and b, 8, is the starting index of list c\n",
+    "segments = ak.array([0, len(a), len(a)+len(b)])\n",
+    "\n",
+    "# Finally, we create our SegArry using the segments and akflat pdarrays\n",
+    "segarr = ak.SegArray(segments, akflat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`GroupBy` is a grouping object that can group together multiple `groupable` objects (`pdarray`, `Strings`, and `Categorical`) or a list of these types. Each component can have multiple registered entries, so to keep things simple we will create two `GroupBy`s using a `pdarray` and `Strings` object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group1 = ak.GroupBy(ak.randint(0,10,100))\n",
+    "group2 = ak.GroupBy(str1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<arkouda.groupbyclass.GroupBy at 0x7efc0051f4f0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "pda1.register('pda1')\n",
-    "str1.register('str1')"
+    "str1.register('str1')\n",
+    "cat1.register('cat1')\n",
+    "segarr.register('segarr')\n",
+    "group1.register('group1')"
    ]
   },
   {
@@ -108,54 +221,121 @@
    "metadata": {},
    "source": [
     "#### Verifying Registration and Using Information Methods\n",
-    "We have just registered `pdarray pda1` and `String str1`. Note that `pdarray pda2` and `String str2` have not been registered. We can verify this using `ak.list_registry`, `.is_registered`, or `.info`"
+    "We have just registered `pdarray pda1`, `String str1`, `Categorical cat1`, `SegArray segarr`, and `GroupBy group1`. Note that `pdarray pda2`, `String str2`, `Categorical cat2`, and `GroupBy group2` have not been registered. We can verify this using `ak.list_registry`, `.is_registered`, or `.info`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['segarr_segments', 'pda1', 'str1', 'segarr_lengths', 'cat1.codes', 'segarr_values', 'group1.permutation', 'group1.segments', 'group1_pdarray.keys', 'cat1.categories', 'cat1._akNAcode', 'cat1.segments', 'cat1.permutation', 'group1_pdarray.unique_keys']\n"
+     ]
+    }
+   ],
    "source": [
     "# ak.list_registry returns a python list of all registered object names\n",
     "print(ak.list_registry())"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "Note that `SegArray` does not currently have a `.is_registered` method, so it is not included here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pda1 is registered: True\n",
+      "pda2 is registered: False\n",
+      "str1 is registered: True\n",
+      "str2 is registered: False\n",
+      "cat1 is registered: True\n",
+      "cat2 is registered: False\n",
+      "group1 is registered: True\n",
+      "group2 is registered: False\n"
+     ]
+    }
+   ],
    "source": [
     "# Class level .is_registered() returns a boolean indicating the object's registration status\n",
     "print(f'pda1 is registered: {pda1.is_registered()}')\n",
     "print(f'pda2 is registered: {pda2.is_registered()}')\n",
     "print(f'str1 is registered: {str1.is_registered()}')\n",
-    "print(f'str2 is registered: {str2.is_registered()}')"
+    "print(f'str2 is registered: {str2.is_registered()}')\n",
+    "print(f'cat1 is registered: {cat1.is_registered()}')\n",
+    "print(f'cat2 is registered: {cat2.is_registered()}')\n",
+    "print(f'group1 is registered: {group1.is_registered()}')\n",
+    "print(f'group2 is registered: {group2.is_registered()}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "str1.info():\n",
+      "[{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true}]\n",
+      "cat1.info():\n",
+      "[{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true}]\n"
+     ]
+    }
+   ],
    "source": [
     "# Class level .info returns all attributes of an object in a JSON formatted string\n",
     "\n",
     "print(\"str1.info():\")\n",
-    "print(str1.info())"
+    "print(str1.info())\n",
+    "\n",
+    "print(\"cat1.info():\")\n",
+    "print(cat1.info())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "str1.pretty_print_info():\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "cat1.pretty_print_info():\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "None\n"
+     ]
+    }
+   ],
    "source": [
     "# Class level .pretty_print_info returns all the attributes from .info in human readable form\n",
     "\n",
     "print(\"str1.pretty_print_info():\")\n",
-    "str1.pretty_print_info()"
+    "str1.pretty_print_info()\n",
+    "\n",
+    "print(\"cat1.pretty_print_info():\")\n",
+    "print(cat1.pretty_print_info())"
    ]
   },
   {
@@ -167,9 +347,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ak.information('registered_object_name'):\n",
+      "[{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true}]\n",
+      "\n",
+      "ak.information(ak.RegisteredSymbols):\n",
+      "[{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true}]\n",
+      "\n",
+      "ak.information(ak.AllSymbols):\n",
+      "[{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_46\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_43\", \"dtype\":\"bool\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_48\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_49\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_30\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_35\", \"dtype\":\"str\", \"size\":101, \"ndim\":1, \"shape\":[101], \"itemsize\":1, \"registered\":false},{\"name\":\"id_DH8F69g_36\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_64\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"id_DH8F69g_24\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_25\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_61\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_62\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_29\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_2\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_4\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_51\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_14\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
+     ]
+    }
+   ],
    "source": [
     "# ak.information returns all attributes of an object in a JSON formatted string\n",
     "# ak.information can be called with a single object, all registered objects, or all objects\n",
@@ -186,9 +381,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ak.pretty_print_information('registered_object_name'):\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "\n",
+      "ak.pretty_print_information(ak.RegisteredSymbols):\n",
+      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "\n",
+      "ak.pretty_print_information(ak.AllSymbols):\n",
+      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_30, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_35, dtype=str, size=101, ndim=1, shape=[101], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_25, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n"
+     ]
+    }
+   ],
    "source": [
     "# all the same arguments can be passed into ak.pretty_print_information for human readable output\n",
     "print(\"ak.pretty_print_information('registered_object_name'):\")\n",
@@ -217,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,9 +491,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before clear:\n",
+      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_30, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_35, dtype=str, size=101, ndim=1, shape=[101], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_25, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_DH8F69g_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_DH8F69g_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
+      "\n",
+      "After clear:\n",
+      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n"
+     ]
+    }
+   ],
    "source": [
     "print('Before clear:')\n",
     "ak.pretty_print_information(ak.AllSymbols)\n",
@@ -268,19 +576,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "pda1 = None\n",
-    "str1 = None"
+    "str1 = None\n",
+    "cat1 = None\n",
+    "segarr = None\n",
+    "group1 = None"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "disconnected from arkouda server tcp://*:5555\n"
+     ]
+    }
+   ],
    "source": [
     "ak.disconnect()"
    ]
@@ -294,9 +613,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "connected to arkouda server tcp://*:5555\n"
+     ]
+    }
+   ],
    "source": [
     "# connect to the arkouda server using the connect_url which the server prints out\n",
     "ak.connect(\"localhost\")"
@@ -304,12 +631,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pda1:None\n",
+      "str1:None\n",
+      "cat1:None\n",
+      "segarr:None\n",
+      "group1:None\n"
+     ]
+    }
+   ],
    "source": [
     "print(f'pda1:{pda1}')\n",
-    "print(f'str1:{str1}')"
+    "print(f'str1:{str1}')\n",
+    "print(f'cat1:{cat1}')\n",
+    "print(f'segarr:{segarr}')\n",
+    "print(f'group1:{group1}')"
    ]
   },
   {
@@ -321,9 +663,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "After reconnect to server:\n",
+      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n"
+     ]
+    }
+   ],
    "source": [
     "print('After reconnect to server:')\n",
     "# ak.pretty_print_information and ak.information without arguments defaults to ak.RegisteredSymbols\n",
@@ -339,22 +703,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "pda1 = ak.pdarray.attach('pda1')\n",
-    "str1 = ak.Strings.attach('str1')"
+    "pda1 = ak.util.attach('pda1')\n",
+    "str1 = ak.util.attach('str1')\n",
+    "cat1 = ak.util.attach('cat1', 'categorical')\n",
+    "segarr = ak.util.attach('segarr', 'segarray')\n",
+    "group1 = ak.GroupBy.attach('group1')\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pda1:[0 3 1 ... 2 4 8]\n",
+      "str1:['GNQE', 'CM', 'MBA', 'LVP', 'YX', 'JHHU', 'GIOQ', 'XJCM', 'NPNG', 'GZRW', 'JCBK', 'YVJZ', 'MMZ', 'QHR', 'SR', 'BU', 'IYLV', 'IC', 'WG', 'RO', 'MH', 'XBK', 'RCF', 'FUZ', 'KTMG', 'LXAI', 'FU', 'KNA', 'HZ', 'UUV', 'CNMG', 'EX', 'YA', 'QL', 'OQQJ', 'RX', 'RU', 'VMCU', 'FJM', 'YIJA', 'PMEL', 'ZZVQ', 'RT', 'YA', 'DPRM', 'BELD', 'EPJ', 'PTQ', 'MM', 'LSV', 'CPA', 'MUWH', 'VGB', 'JJDH', 'XD', 'NJZH', 'OGK', 'AWGM', 'ZL', 'BFA', 'JXV', 'SR', 'PA', 'TGF', 'JEE', 'CWH', 'NIV', 'PGEC', 'UEO', 'ZZND', 'MTWO', 'KON', 'UW', 'ID', 'JER', 'NVF', 'OP', 'THZF', 'EGSG', 'HR', 'NP', 'DFUU', 'CC', 'XQFZ', 'AK', 'XPR', 'AYCI', 'GOEO', 'LBWJ', 'MVGO', 'PAH', 'MSEA', 'CU', 'SVV', 'FW', 'MDXJ', 'BJZ', 'TGVJ', 'HKIG', 'VU']\n",
+      "cat1:['GNQE', 'CM', 'MBA', 'LVP', 'YX', 'JHHU', 'GIOQ', 'XJCM', 'NPNG', 'GZRW', 'JCBK', 'YVJZ', 'MMZ', 'QHR', 'SR', 'BU', 'IYLV', 'IC', 'WG', 'RO', 'MH', 'XBK', 'RCF', 'FUZ', 'KTMG', 'LXAI', 'FU', 'KNA', 'HZ', 'UUV', 'CNMG', 'EX', 'YA', 'QL', 'OQQJ', 'RX', 'RU', 'VMCU', 'FJM', 'YIJA', 'PMEL', 'ZZVQ', 'RT', 'YA', 'DPRM', 'BELD', 'EPJ', 'PTQ', 'MM', 'LSV', 'CPA', 'MUWH', 'VGB', 'JJDH', 'XD', 'NJZH', 'OGK', 'AWGM', 'ZL', 'BFA', 'JXV', 'SR', 'PA', 'TGF', 'JEE', 'CWH', 'NIV', 'PGEC', 'UEO', 'ZZND', 'MTWO', 'KON', 'UW', 'ID', 'JER', 'NVF', 'OP', 'THZF', 'EGSG', 'HR', 'NP', 'DFUU', 'CC', 'XQFZ', 'AK', 'XPR', 'AYCI', 'GOEO', 'LBWJ', 'MVGO', 'PAH', 'MSEA', 'CU', 'SVV', 'FW', 'MDXJ', 'BJZ', 'TGVJ', 'HKIG', 'VU']\n",
+      "segarr:SegArray([\n",
+      "[10 11 12 13 14 15]\n",
+      "[20 21]\n",
+      "[30 31 32 33]\n",
+      "])\n",
+      "group1:<arkouda.groupbyclass.GroupBy object at 0x7efbc72a11c0>\n"
+     ]
+    }
+   ],
    "source": [
     "print(f'pda1:{pda1}')\n",
-    "print(f'str1:{str1}')"
+    "print(f'str1:{str1}')\n",
+    "print(f'cat1:{cat1}')\n",
+    "print(f'segarr:{segarr}')\n",
+    "print(f'group1:{group1}')"
    ]
   },
   {
@@ -366,27 +752,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
     "pda1.unregister()\n",
     "str1.unregister()\n",
+    "cat1.unregister()\n",
+    "segarr.unregister()\n",
+    "group1.unregister()\n",
     "ak.clear()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
+     ]
+    }
+   ],
    "source": [
     "print(ak.information(ak.AllSymbols))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,8 +792,11 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "ee1fbf9983315a0ac5f6fc85414702271de8c5a8d740b4149bd7f5bb1b490f8e"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -410,7 +810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/Registration_Example.ipynb
+++ b/Registration_Example.ipynb
@@ -58,24 +58,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    _         _                   _       \n",
-      "   / \\   _ __| | _____  _   _  __| | __ _ \n",
-      "  / _ \\ | '__| |/ / _ \\| | | |/ _` |/ _` |\n",
-      " / ___ \\| |  |   < (_) | |_| | (_| | (_| |\n",
-      "/_/   \\_\\_|  |_|\\_\\___/ \\__,_|\\__,_|\\__,_|\n",
-      "                                          \n",
-      "\n",
-      "Client Version: v2022.05.09+14.gd0b5bef2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import arkouda as ak"
    ]
@@ -89,17 +74,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "connected to arkouda server tcp://*:5555\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# connect to the arkouda server using the connect_url which the server prints out\n",
     "ak.connect(connect_url=\"tcp://localhost:5555\")"
@@ -115,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,20 +169,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<arkouda.groupbyclass.GroupBy at 0x7f218c168a90>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pda1.register('pda1')\n",
     "str1.register('str1')\n",
@@ -224,17 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['segarr_segments', 'pda1', 'str1', 'segarr_lengths', 'cat1.codes', 'segarr_values', 'group1.permutation', 'group1.segments', 'group1_pdarray.keys', 'cat1.permutation', 'cat1._akNAcode', 'cat1.segments', 'cat1.categories', 'group1_pdarray.unique_keys']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ak.list_registry returns a python list of all registered object names\n",
     "print(ak.list_registry())"
@@ -249,24 +207,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pda1 is registered: True\n",
-      "pda2 is registered: False\n",
-      "str1 is registered: True\n",
-      "str2 is registered: False\n",
-      "cat1 is registered: True\n",
-      "cat2 is registered: False\n",
-      "group1 is registered: True\n",
-      "group2 is registered: False\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Class level .is_registered() returns a boolean indicating the object's registration status\n",
     "print(f'pda1 is registered: {pda1.is_registered()}')\n",
@@ -281,20 +224,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "str1.info():\n",
-      "[{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true}]\n",
-      "cat1.info():\n",
-      "[{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Class level .info returns all attributes of an object in a JSON formatted string\n",
     "\n",
@@ -307,25 +239,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "str1.pretty_print_info():\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "cat1.pretty_print_info():\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Class level .pretty_print_info returns all the attributes from .info in human readable form\n",
     "\n",
@@ -345,24 +261,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ak.information('registered_object_name'):\n",
-      "[{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true}]\n",
-      "\n",
-      "ak.information(ak.RegisteredSymbols):\n",
-      "[{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true}]\n",
-      "\n",
-      "ak.information(ak.AllSymbols):\n",
-      "[{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_43\", \"dtype\":\"bool\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":1, \"registered\":false},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_46\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_49\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_48\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_14\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_51\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_4\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"id_xg7lS19_2\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_25\", \"dtype\":\"int64\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_24\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_61\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_62\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_64\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_29\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"id_xg7lS19_35\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"id_xg7lS19_36\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":false},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_30\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ak.information returns all attributes of an object in a JSON formatted string\n",
     "# ak.information can be called with a single object, all registered objects, or all objects\n",
@@ -379,67 +280,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ak.pretty_print_information('registered_object_name'):\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "\n",
-      "ak.pretty_print_information(ak.RegisteredSymbols):\n",
-      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "\n",
-      "ak.pretty_print_information(ak.AllSymbols):\n",
-      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
-      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_25, dtype=int64, size=99, ndim=1, shape=[99], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_35, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
-      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_30, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=False)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# all the same arguments can be passed into ak.pretty_print_information for human readable output\n",
     "print(\"ak.pretty_print_information('registered_object_name'):\")\n",
@@ -468,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,64 +332,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Before clear:\n",
-      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
-      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_25, dtype=int64, size=99, ndim=1, shape=[99], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_35, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_xg7lS19_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
-      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_xg7lS19_30, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=False)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "\n",
-      "After clear:\n",
-      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Before clear:')\n",
     "ak.pretty_print_information(ak.AllSymbols)\n",
@@ -574,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,17 +375,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "disconnected from arkouda server tcp://*:5555\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ak.disconnect()"
    ]
@@ -611,17 +391,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "connected to arkouda server tcp://*:5555\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# connect to the arkouda server using the connect_url which the server prints out\n",
     "ak.connect(\"localhost\")"
@@ -629,21 +401,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pda1:None\n",
-      "str1:None\n",
-      "cat1:None\n",
-      "segarr:None\n",
-      "group1:None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f'pda1:{pda1}')\n",
     "print(f'str1:{str1}')\n",
@@ -661,31 +421,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "After reconnect to server:\n",
-      "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
-      "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('After reconnect to server:')\n",
     "# ak.pretty_print_information and ak.information without arguments defaults to ak.RegisteredSymbols\n",
@@ -701,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,25 +452,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pda1:[5 2 3 ... 1 4 3]\n",
-      "str1:['PH', 'EG', 'OR', 'XGW', 'JY', 'VPO', 'SBAW', 'ICQT', 'WVNP', 'UC', 'SG', 'DTL', 'NJF', 'ACG', 'XZBG', 'JKUF', 'ZU', 'QXDA', 'FE', 'TJ', 'QWUG', 'WMWP', 'CA', 'ARJ', 'KYW', 'VK', 'ZG', 'MA', 'GDZL', 'PVR', 'HROU', 'LOUX', 'DWI', 'PHK', 'AN', 'OUQC', 'IXD', 'MGP', 'VIZ', 'IU', 'XRM', 'AB', 'SP', 'EPS', 'MUR', 'VHQ', 'XUI', 'DNRN', 'IOX', 'QDBL', 'JSQH', 'HW', 'BLA', 'RHS', 'RBVU', 'EW', 'WLVR', 'QA', 'MXI', 'UJMT', 'ZX', 'QMX', 'YYX', 'FW', 'BEV', 'GDUO', 'EQ', 'NPN', 'IHZ', 'PAS', 'BU', 'FRP', 'LQY', 'XI', 'KQR', 'THEA', 'QP', 'FP', 'SG', 'VT', 'AI', 'ROFO', 'QWD', 'NV', 'YYK', 'TQRR', 'RB', 'SKFT', 'JCTR', 'NPZK', 'NKH', 'AOP', 'RI', 'HT', 'DM', 'FB', 'ZX', 'OFSF', 'JGY', 'SPIU']\n",
-      "cat1:['PH', 'EG', 'OR', 'XGW', 'JY', 'VPO', 'SBAW', 'ICQT', 'WVNP', 'UC', 'SG', 'DTL', 'NJF', 'ACG', 'XZBG', 'JKUF', 'ZU', 'QXDA', 'FE', 'TJ', 'QWUG', 'WMWP', 'CA', 'ARJ', 'KYW', 'VK', 'ZG', 'MA', 'GDZL', 'PVR', 'HROU', 'LOUX', 'DWI', 'PHK', 'AN', 'OUQC', 'IXD', 'MGP', 'VIZ', 'IU', 'XRM', 'AB', 'SP', 'EPS', 'MUR', 'VHQ', 'XUI', 'DNRN', 'IOX', 'QDBL', 'JSQH', 'HW', 'BLA', 'RHS', 'RBVU', 'EW', 'WLVR', 'QA', 'MXI', 'UJMT', 'ZX', 'QMX', 'YYX', 'FW', 'BEV', 'GDUO', 'EQ', 'NPN', 'IHZ', 'PAS', 'BU', 'FRP', 'LQY', 'XI', 'KQR', 'THEA', 'QP', 'FP', 'SG', 'VT', 'AI', 'ROFO', 'QWD', 'NV', 'YYK', 'TQRR', 'RB', 'SKFT', 'JCTR', 'NPZK', 'NKH', 'AOP', 'RI', 'HT', 'DM', 'FB', 'ZX', 'OFSF', 'JGY', 'SPIU']\n",
-      "segarr:SegArray([\n",
-      "[10 11 12 13 14 15]\n",
-      "[20 21]\n",
-      "[30 31 32 33]\n",
-      "])\n",
-      "group1:<arkouda.groupbyclass.GroupBy object at 0x7f21546f2340>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f'pda1:{pda1}')\n",
     "print(f'str1:{str1}')\n",
@@ -750,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,24 +486,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(ak.information(ak.AllSymbols))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/Registration_Example.ipynb
+++ b/Registration_Example.ipynb
@@ -72,7 +72,7 @@
       "/_/   \\_\\_|  |_|\\_\\___/ \\__,_|\\__,_|\\__,_|\n",
       "                                          \n",
       "\n",
-      "Client Version: v2022.05.09+19.g81249870\n"
+      "Client Version: v2022.05.09+14.gd0b5bef2\n"
      ]
     }
    ],
@@ -96,8 +96,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/josh/git/arkouda/arkouda/client.py:147: RuntimeWarning: Version mismatch between client (v2022.05.09+19.g81249870) and server (v2022.05.09+15.g8ea55dba.dirty); this may cause some commands to fail or behave incorrectly! Updating arkouda is strongly recommended.\n",
-      "  warnings.warn(('Version mismatch between client ({}) and server ({}); ' +\n",
       "connected to arkouda server tcp://*:5555\n"
      ]
     }
@@ -200,7 +198,7 @@
     {
      "data": {
       "text/plain": [
-       "<arkouda.groupbyclass.GroupBy at 0x7efc0051f4f0>"
+       "<arkouda.groupbyclass.GroupBy at 0x7f218c168a90>"
       ]
      },
      "execution_count": 7,
@@ -233,7 +231,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['segarr_segments', 'pda1', 'str1', 'segarr_lengths', 'cat1.codes', 'segarr_values', 'group1.permutation', 'group1.segments', 'group1_pdarray.keys', 'cat1.categories', 'cat1._akNAcode', 'cat1.segments', 'cat1.permutation', 'group1_pdarray.unique_keys']\n"
+      "['segarr_segments', 'pda1', 'str1', 'segarr_lengths', 'cat1.codes', 'segarr_values', 'group1.permutation', 'group1.segments', 'group1_pdarray.keys', 'cat1.permutation', 'cat1._akNAcode', 'cat1.segments', 'cat1.categories', 'group1_pdarray.unique_keys']\n"
      ]
     }
    ],
@@ -293,7 +291,7 @@
       "str1.info():\n",
       "[{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true}]\n",
       "cat1.info():\n",
-      "[{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true}]\n"
+      "[{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
      ]
     }
    ],
@@ -319,11 +317,11 @@
       "str1.pretty_print_info():\n",
       "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
       "cat1.pretty_print_info():\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
-      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
       "None\n"
      ]
     }
@@ -358,10 +356,10 @@
       "[{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true}]\n",
       "\n",
       "ak.information(ak.RegisteredSymbols):\n",
-      "[{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true}]\n",
+      "[{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true}]\n",
       "\n",
       "ak.information(ak.AllSymbols):\n",
-      "[{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_46\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_43\", \"dtype\":\"bool\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_48\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_49\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_30\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_35\", \"dtype\":\"str\", \"size\":101, \"ndim\":1, \"shape\":[101], \"itemsize\":1, \"registered\":false},{\"name\":\"id_DH8F69g_36\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_64\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"id_DH8F69g_24\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_25\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_61\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_62\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_29\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_2\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_4\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_DH8F69g_51\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_DH8F69g_14\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
+      "[{\"name\":\"segarr_lengths\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_43\", \"dtype\":\"bool\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":1, \"registered\":false},{\"name\":\"segarr_values\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_46\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_49\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_48\", \"dtype\":\"int64\", \"size\":12, \"ndim\":1, \"shape\":[12], \"itemsize\":8, \"registered\":false},{\"name\":\"cat1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"segarr_segments\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_14\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"group1_pdarray.keys\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_51\", \"dtype\":\"int64\", \"size\":3, \"ndim\":1, \"shape\":[3], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_4\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"id_xg7lS19_2\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_25\", \"dtype\":\"int64\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_24\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_61\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_62\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":false},{\"name\":\"id_xg7lS19_64\", \"dtype\":\"str\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_29\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":false},{\"name\":\"group1_pdarray.unique_keys\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"pda1\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"str1\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":true},{\"name\":\"id_xg7lS19_35\", \"dtype\":\"str\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":1, \"registered\":false},{\"name\":\"id_xg7lS19_36\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":false},{\"name\":\"group1.permutation\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"id_xg7lS19_30\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":false},{\"name\":\"cat1.codes\", \"dtype\":\"int64\", \"size\":100, \"ndim\":1, \"shape\":[100], \"itemsize\":8, \"registered\":true},{\"name\":\"group1.segments\", \"dtype\":\"int64\", \"size\":10, \"ndim\":1, \"shape\":[10], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.categories\", \"dtype\":\"str\", \"size\":99, \"ndim\":1, \"shape\":[99], \"itemsize\":1, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
      ]
     }
    ],
@@ -401,43 +399,43 @@
       "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
       "\n",
       "ak.pretty_print_information(ak.AllSymbols):\n",
       "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
       "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
       "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_30, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
       "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_35, dtype=str, size=101, ndim=1, shape=[101], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_25, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_25, dtype=int64, size=99, ndim=1, shape=[99], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_xg7lS19_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
       "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
       "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=id_xg7lS19_35, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
       "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_30, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=False)\n",
       "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n"
      ]
     }
@@ -500,35 +498,35 @@
      "text": [
       "Before clear:\n",
       "InfoEntry(name=segarr_lengths, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
       "InfoEntry(name=segarr_values, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_43, dtype=bool, size=3, ndim=1, shape=[3], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_46, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
       "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_48, dtype=int64, size=12, ndim=1, shape=[12], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_49, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_30, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
       "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_35, dtype=str, size=101, ndim=1, shape=[101], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_25, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_25, dtype=int64, size=99, ndim=1, shape=[99], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_24, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_61, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_62, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_64, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
+      "InfoEntry(name=id_xg7lS19_29, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
       "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_2, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=False)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
       "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_4, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
+      "InfoEntry(name=id_xg7lS19_35, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_36, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=False)\n",
       "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=id_DH8F69g_51, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=False)\n",
-      "InfoEntry(name=id_DH8F69g_14, dtype=str, size=98, ndim=1, shape=[98], itemsize=1, registered=False)\n",
+      "InfoEntry(name=id_xg7lS19_30, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=False)\n",
       "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
       "\n",
       "After clear:\n",
@@ -538,8 +536,8 @@
       "InfoEntry(name=segarr_segments, dtype=int64, size=3, ndim=1, shape=[3], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
-      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
       "InfoEntry(name=pda1, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=str1, dtype=str, size=100, ndim=1, shape=[100], itemsize=1, registered=True)\n",
       "InfoEntry(name=cat1.codes, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
@@ -680,10 +678,10 @@
       "InfoEntry(name=group1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1.segments, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n",
       "InfoEntry(name=group1_pdarray.keys, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
+      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1._akNAcode, dtype=int64, size=1, ndim=1, shape=[1], itemsize=8, registered=True)\n",
       "InfoEntry(name=cat1.segments, dtype=int64, size=98, ndim=1, shape=[98], itemsize=8, registered=True)\n",
-      "InfoEntry(name=cat1.permutation, dtype=int64, size=100, ndim=1, shape=[100], itemsize=8, registered=True)\n",
+      "InfoEntry(name=cat1.categories, dtype=str, size=99, ndim=1, shape=[99], itemsize=1, registered=True)\n",
       "InfoEntry(name=group1_pdarray.unique_keys, dtype=int64, size=10, ndim=1, shape=[10], itemsize=8, registered=True)\n"
      ]
     }
@@ -723,15 +721,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "pda1:[0 3 1 ... 2 4 8]\n",
-      "str1:['GNQE', 'CM', 'MBA', 'LVP', 'YX', 'JHHU', 'GIOQ', 'XJCM', 'NPNG', 'GZRW', 'JCBK', 'YVJZ', 'MMZ', 'QHR', 'SR', 'BU', 'IYLV', 'IC', 'WG', 'RO', 'MH', 'XBK', 'RCF', 'FUZ', 'KTMG', 'LXAI', 'FU', 'KNA', 'HZ', 'UUV', 'CNMG', 'EX', 'YA', 'QL', 'OQQJ', 'RX', 'RU', 'VMCU', 'FJM', 'YIJA', 'PMEL', 'ZZVQ', 'RT', 'YA', 'DPRM', 'BELD', 'EPJ', 'PTQ', 'MM', 'LSV', 'CPA', 'MUWH', 'VGB', 'JJDH', 'XD', 'NJZH', 'OGK', 'AWGM', 'ZL', 'BFA', 'JXV', 'SR', 'PA', 'TGF', 'JEE', 'CWH', 'NIV', 'PGEC', 'UEO', 'ZZND', 'MTWO', 'KON', 'UW', 'ID', 'JER', 'NVF', 'OP', 'THZF', 'EGSG', 'HR', 'NP', 'DFUU', 'CC', 'XQFZ', 'AK', 'XPR', 'AYCI', 'GOEO', 'LBWJ', 'MVGO', 'PAH', 'MSEA', 'CU', 'SVV', 'FW', 'MDXJ', 'BJZ', 'TGVJ', 'HKIG', 'VU']\n",
-      "cat1:['GNQE', 'CM', 'MBA', 'LVP', 'YX', 'JHHU', 'GIOQ', 'XJCM', 'NPNG', 'GZRW', 'JCBK', 'YVJZ', 'MMZ', 'QHR', 'SR', 'BU', 'IYLV', 'IC', 'WG', 'RO', 'MH', 'XBK', 'RCF', 'FUZ', 'KTMG', 'LXAI', 'FU', 'KNA', 'HZ', 'UUV', 'CNMG', 'EX', 'YA', 'QL', 'OQQJ', 'RX', 'RU', 'VMCU', 'FJM', 'YIJA', 'PMEL', 'ZZVQ', 'RT', 'YA', 'DPRM', 'BELD', 'EPJ', 'PTQ', 'MM', 'LSV', 'CPA', 'MUWH', 'VGB', 'JJDH', 'XD', 'NJZH', 'OGK', 'AWGM', 'ZL', 'BFA', 'JXV', 'SR', 'PA', 'TGF', 'JEE', 'CWH', 'NIV', 'PGEC', 'UEO', 'ZZND', 'MTWO', 'KON', 'UW', 'ID', 'JER', 'NVF', 'OP', 'THZF', 'EGSG', 'HR', 'NP', 'DFUU', 'CC', 'XQFZ', 'AK', 'XPR', 'AYCI', 'GOEO', 'LBWJ', 'MVGO', 'PAH', 'MSEA', 'CU', 'SVV', 'FW', 'MDXJ', 'BJZ', 'TGVJ', 'HKIG', 'VU']\n",
+      "pda1:[5 2 3 ... 1 4 3]\n",
+      "str1:['PH', 'EG', 'OR', 'XGW', 'JY', 'VPO', 'SBAW', 'ICQT', 'WVNP', 'UC', 'SG', 'DTL', 'NJF', 'ACG', 'XZBG', 'JKUF', 'ZU', 'QXDA', 'FE', 'TJ', 'QWUG', 'WMWP', 'CA', 'ARJ', 'KYW', 'VK', 'ZG', 'MA', 'GDZL', 'PVR', 'HROU', 'LOUX', 'DWI', 'PHK', 'AN', 'OUQC', 'IXD', 'MGP', 'VIZ', 'IU', 'XRM', 'AB', 'SP', 'EPS', 'MUR', 'VHQ', 'XUI', 'DNRN', 'IOX', 'QDBL', 'JSQH', 'HW', 'BLA', 'RHS', 'RBVU', 'EW', 'WLVR', 'QA', 'MXI', 'UJMT', 'ZX', 'QMX', 'YYX', 'FW', 'BEV', 'GDUO', 'EQ', 'NPN', 'IHZ', 'PAS', 'BU', 'FRP', 'LQY', 'XI', 'KQR', 'THEA', 'QP', 'FP', 'SG', 'VT', 'AI', 'ROFO', 'QWD', 'NV', 'YYK', 'TQRR', 'RB', 'SKFT', 'JCTR', 'NPZK', 'NKH', 'AOP', 'RI', 'HT', 'DM', 'FB', 'ZX', 'OFSF', 'JGY', 'SPIU']\n",
+      "cat1:['PH', 'EG', 'OR', 'XGW', 'JY', 'VPO', 'SBAW', 'ICQT', 'WVNP', 'UC', 'SG', 'DTL', 'NJF', 'ACG', 'XZBG', 'JKUF', 'ZU', 'QXDA', 'FE', 'TJ', 'QWUG', 'WMWP', 'CA', 'ARJ', 'KYW', 'VK', 'ZG', 'MA', 'GDZL', 'PVR', 'HROU', 'LOUX', 'DWI', 'PHK', 'AN', 'OUQC', 'IXD', 'MGP', 'VIZ', 'IU', 'XRM', 'AB', 'SP', 'EPS', 'MUR', 'VHQ', 'XUI', 'DNRN', 'IOX', 'QDBL', 'JSQH', 'HW', 'BLA', 'RHS', 'RBVU', 'EW', 'WLVR', 'QA', 'MXI', 'UJMT', 'ZX', 'QMX', 'YYX', 'FW', 'BEV', 'GDUO', 'EQ', 'NPN', 'IHZ', 'PAS', 'BU', 'FRP', 'LQY', 'XI', 'KQR', 'THEA', 'QP', 'FP', 'SG', 'VT', 'AI', 'ROFO', 'QWD', 'NV', 'YYK', 'TQRR', 'RB', 'SKFT', 'JCTR', 'NPZK', 'NKH', 'AOP', 'RI', 'HT', 'DM', 'FB', 'ZX', 'OFSF', 'JGY', 'SPIU']\n",
       "segarr:SegArray([\n",
       "[10 11 12 13 14 15]\n",
       "[20 21]\n",
       "[30 31 32 33]\n",
       "])\n",
-      "group1:<arkouda.groupbyclass.GroupBy object at 0x7efbc72a11c0>\n"
+      "group1:<arkouda.groupbyclass.GroupBy object at 0x7f21546f2340>\n"
      ]
     }
    ],
@@ -747,7 +745,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We restored our access to `pda1` and `str1` using the `attach` functionality. Now we unregister everything and shutdown the arkouda server "
+    "We restored our access to `pda1`, `str1`, `cat1`, `segarr`, and `group1` using the `attach` functionality. Now we unregister everything and shutdown the arkouda server "
    ]
   },
   {
@@ -773,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{\"name\":\"cat1._akNAcode\", \"dtype\":\"int64\", \"size\":1, \"ndim\":1, \"shape\":[1], \"itemsize\":8, \"registered\":true},{\"name\":\"cat1.segments\", \"dtype\":\"int64\", \"size\":98, \"ndim\":1, \"shape\":[98], \"itemsize\":8, \"registered\":true}]\n"
+      "[]\n"
      ]
     }
    ],
@@ -793,7 +791,7 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "ee1fbf9983315a0ac5f6fc85414702271de8c5a8d740b4149bd7f5bb1b490f8e"
+   "hash": "602ef4e43bc5e522b9fa8254db2ce3bcd48b16c5cd430020a77bd45828b6d245"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",


### PR DESCRIPTION
This PR (closes #20):

Draft until main repo PRs #1327 and #1391 are merged.

This is the initial commit with updates for the generic attach method as well as `GroupBy` and `SegArray`s register functionality being included. Once the mentioned PRs are merged, I will rerun the notebook to verify it's correct, but until they're merged the `unregister` piece will fail to unregister `Categorical` and `GroupBy` cannot be `registered/attached`.