### PR TITLE
Closes #25 - Add Arkouda Basics Notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ipynb_checkpoints
+.idea

--- a/ArkoudaDemoBasics.ipynb
+++ b/ArkoudaDemoBasics.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Arkouda\n",
+    "## Comparison to Numpy/Pandas\n",
+    "\n",
+    "The majority of the API for arkouda functions very similarly to that of Numpy or Pandas. However, under the hood, Arkouda is sending messages out to the Chapel Server for processing. This demo will highlight the key similarities between Arkouda and NumPy/Pandas. Additionally, we will explore some of the chapel functionality making this possible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Importing\n",
+    "This may seem like a trivial step to highlight, but Arkouda requires the user establish a connection to the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import arkouda as ak\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "ak.connect()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Arrays\n",
+    "### Python List"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Creation from python list\n",
+    "a = [0, 1, 2, 3, 4]\n",
+    "ak_array = ak.array(a)\n",
+    "display(ak_array)\n",
+    "\n",
+    "np_array = np.array(a)\n",
+    "display(np_array)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Arange"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# arange functionality\n",
+    "ak_array = ak.arange(10)\n",
+    "display(ak_array)\n",
+    "\n",
+    "np_array = np.arange(10)\n",
+    "display(np_array)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### NumPy to Arkouda"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np_arr = np.arange(10)\n",
+    "display(np_arr)\n",
+    "\n",
+    "from_np = ak.array(np_arr)\n",
+    "display(from_np)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Arkouda to NumPy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ak_arr = ak.arange(10)\n",
+    "display(ak_arr)\n",
+    "\n",
+    "np_arr = ak_arr.to_ndarray()\n",
+    "display(np_arr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Array Functionality\n",
+    "### Set Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np_arr = np.array([4, 2, 5, 6, 4, 7, 2])\n",
+    "np_arr2 = np.array([1, 5, 4, 11, 9, 6])\n",
+    "np_in1d = np.in1d(np_arr, np_arr2)\n",
+    "np_int = np.intersect1d(np_arr, np_arr2)\n",
+    "\n",
+    "ak_arr = ak.array(np_arr)\n",
+    "ak_arr2 = ak.array(np_arr2)\n",
+    "ak_in1d = ak.in1d(ak_arr, ak_arr2)\n",
+    "ak_int = ak.intersect1d(ak_arr, ak_arr2)\n",
+    "\n",
+    "# Arkouda can perform this operation on multiple arrays at once\n",
+    "m1 =[\n",
+    "    ak.array([0, 1, 3, 4, 8, 5, 0]),\n",
+    "    ak.array([0, 9, 5, 1, 8, 5, 0])\n",
+    "]\n",
+    "m2 =[\n",
+    "    ak.array([0, 1, 3, 4, 8, 7]),\n",
+    "    ak.array([0, 2, 5, 9, 8, 5])\n",
+    "]\n",
+    "ak_in1dmult = ak.in1d(m1, m2)\n",
+    "ak_intmult = ak.intersect1d(m1, m2)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this block is for display purposes only\n",
+    "from ipywidgets import *\n",
+    "\n",
+    "np_out = Output()\n",
+    "with np_out:\n",
+    "    display(HTML(\"<h3 style='margin:0'>in1d</h3>\"))\n",
+    "    display(np_in1d)\n",
+    "    display(HTML(\"<h3 style='margin:0'>intersect1d</h3>\"))\n",
+    "    display(np_int)\n",
+    "\n",
+    "ak_out = Output()\n",
+    "with ak_out:\n",
+    "    display(HTML(\"<h3 style='margin:0'>in1d</h3>\"))\n",
+    "    display(ak_in1d)\n",
+    "    display(HTML(\"<h3 style='margin:0'>intersect1d</h3>\"))\n",
+    "    display(ak_int)\n",
+    "    display(HTML(\"<h3 style='margin:0'>in1d (multi)</h3>\"))\n",
+    "    display(ak_in1dmult)\n",
+    "    display(HTML(\"<h3 style='margin:0'>intersect1d (multi)</h3>\"))\n",
+    "    display(ak_intmult)\n",
+    "\n",
+    "container = HBox([\n",
+    "    VBox([\n",
+    "        HTML(\"<h2>NumPy</h2>\"),\n",
+    "        np_out\n",
+    "    ], layout=Layout(width='50%')),\n",
+    "    VBox([\n",
+    "        HTML(\"<h2>Arkouda</h2>\"),\n",
+    "        ak_out\n",
+    "    ], layout=Layout(width='50%'))\n",
+    "])\n",
+    "\n",
+    "display(container)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GroupBy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np_grp_keys, np_grp_cts = np.unique(np_arr, return_counts=True)\n",
+    "\n",
+    "g = ak.GroupBy(ak_arr)\n",
+    "ak_grp_keys, ak_grp_cts = g.count()\n",
+    "\n",
+    "g2 = ak.GroupBy(m1)\n",
+    "ak_2_keys, ak_2_cts = g2.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np_outg = Output()\n",
+    "with np_outg:\n",
+    "    display(HTML(\"<h3 style='margin:0'>Keys</h3>\"))\n",
+    "    display(np_grp_keys)\n",
+    "    display(HTML(\"<h3 style='margin:0'>Counts</h3>\"))\n",
+    "    display(np_grp_cts)\n",
+    "\n",
+    "ak_outg = Output()\n",
+    "with ak_outg:\n",
+    "    display(HTML(\"<h3 style='margin:0'>Keys</h3>\"))\n",
+    "    display(ak_grp_keys)\n",
+    "    display(HTML(\"<h3 style='margin:0'>Counts</h3>\"))\n",
+    "    display(ak_grp_cts)\n",
+    "    display(HTML(\"<b>Arkouda is able to process multiple arrays at once, similar to Pandas grouping DataFrames.</b>\"))\n",
+    "    display(HTML(\"<h3 style='margin:0'>Keys (Multi)</h3>\"))\n",
+    "    display(ak_2_keys)\n",
+    "    display(HTML(\"<h3 style='margin:0'>Counts (Multi)</h3>\"))\n",
+    "    display(ak_2_cts)\n",
+    "\n",
+    "grp_container = HBox([\n",
+    "    VBox([\n",
+    "        HTML(\"<h2>NumPy</h2>\"),\n",
+    "        np_outg\n",
+    "    ], layout=Layout(width='50%')),\n",
+    "    VBox([\n",
+    "        HTML(\"<h2>Arkouda</h2>\"),\n",
+    "        ak_outg\n",
+    "    ], layout=Layout(width='50%'))\n",
+    "])\n",
+    "\n",
+    "display(grp_container)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating DataFrames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = ['John', 'Jane', 'John', 'Jake']\n",
+    "lname = ['Doe', 'Doe', 'Smith', 'FromStateFarm']\n",
+    "age = [37, 35, 50, 32]\n",
+    "salary = [75000, 77000, 100000, 35000]\n",
+    "\n",
+    "ak_df = ak.DataFrame({\n",
+    "    'F_Name': ak.array(fname),\n",
+    "    'L_Name': ak.array(lname),\n",
+    "    'Age': ak.array(age),\n",
+    "    'Salary': ak.array(salary)\n",
+    "})\n",
+    "display(ak_df)\n",
+    "\n",
+    "pd_df = pd.DataFrame({\n",
+    "    'F_Name': fname,\n",
+    "    'L_Name': lname,\n",
+    "    'Age': age,\n",
+    "    'Salary': salary\n",
+    "})\n",
+    "display(pd_df)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pandas to Arkouda"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# using the pandas dataframe from the previous cell\n",
+    "ak_df = ak.DataFrame(pd_df)\n",
+    "display(ak_df)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Arkouda to Pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# using the arkouda dataframe from the previous cell\n",
+    "pd_df = ak_df.to_pandas()\n",
+    "display(pd_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame GroupBy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ak_g = ak_df.GroupBy(\"F_Name\")\n",
+    "display(ak_g.count())\n",
+    "\n",
+    "pd_g = pd_df.groupby(by=\"F_Name\", axis=0)\n",
+    "display(pd_g.count())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame Sorting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "perm = ak_df.argsort(\"F_Name\")\n",
+    "display(ak_df[perm])\n",
+    "\n",
+    "display(pd_df.sort_values(by=\"F_Name\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Disconnecting from the Arkouda Server\n",
+    "\n",
+    "### Disconnect\n",
+    "`ak.disconnect()`<br>\n",
+    "This disconnects the user's client from the server, but allows the server to continue running. This is more commonly used on distributed systems where multiple users may be leveraging the same Arkouda Server.\n",
+    "\n",
+    "### Shutdown\n",
+    "`ak.shutdown()`<br>\n",
+    "This disconnects the user's client from the server, but also shuts the server down completely. This is useful when running tests on a personal computer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ak.disconnect()\n",
+    "ak.shutdown()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.5 ('ak-dev')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f37bde146169874234f182107f40d5d4ed1287a2715b948ba1b35c9b1d6710cd"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes #25 

Adds a basic Arkouda Demo Notebook. This Notebook provides:
- Basic examples of Arkouda vs NumPy/Pandas.
- Creating Arkouda objects and then transferring those objects to NumPy/Pandas
- GroupBy Functionality
- DataFrame Functionality